### PR TITLE
Add a requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+lightcurve>=0.5.1
+matplotlib>=1.5.1
+numpy>=1.11.1
+orbit>=0.2
+pyfits>=3.4
+pylab>=0.1.3
+pyraf>=2.1.10
+scipy>=0.17.1


### PR DESCRIPTION
The `requirements.txt` file includes a list of packages to install, instead of running a sequence of `pip install` commands, we just run `pip install -r requirements.txt` and we get all the dependencies. This is really useful when you're starting with `pyKE`, which is my case.

*NOTE:* I just created a virtual environment with `virtualenv` and then I began to install all the packages listed in the `import` directives.

Please let me know what do you think.