### PR TITLE
linewidth cannot be a string

### DIFF
--- a/pyke/kepflatten.py
+++ b/pyke/kepflatten.py
@@ -296,7 +296,7 @@ def kepflatten(infile, outfile, datacol='PDCSAP_FLUX',
     masterfit[-1] = masterfit[-4] #fudge
     masterfit[-2] = masterfit[-4] #fudge
     masterfit[-3] = masterfit[-4] #fudge
-    plt.plot(intime - intime0, masterfit / 10 ** nrm, 'g', lw='3')
+    plt.plot(intime - intime0, masterfit / 10 ** nrm, 'g', lw=3)
 
     # reject outliers
     rejtime, rejdata = [], []

--- a/pyke/kepoutlier.py
+++ b/pyke/kepoutlier.py
@@ -257,7 +257,7 @@ def kepoutlier(infile, outfile, datacol, nsig=3.0, stepsize=1.0, npoly=3,
                 mastersigma[j] = sigma
             if plotfit:
                 plt.plot(plotx + intime[cstep1[i]] - intime0, ploty / 10 ** nrm,
-                         'g', lw='3')
+                         'g', lw=3)
         except:
             for j in range(cstep1[i], cstep2[i] + 1):
                 masterfit[j] = indata[j]


### PR DESCRIPTION
`kepflatten` doesn't appear to be working because the plotting feature used `lw='3'` instead of `lw=3`.  Fixed it!