### PR TITLE
Fix travis for Python 2.7 by installing numpy/scipy/astropy via apt-get instead of pip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - 3.5
   - 3.6
 before_install:
-  - sudo apt-get install -y python-numpy python-scipy python-astropy
+  - sudo apt-get install -y python-numpy python-scipy
 install:
   - pip install -r requirements.txt
 # command to run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ python:
   - 2.7
   - 3.5
   - 3.6
-# command to install dependencies
+before_install:
+  - sudo apt-get install -y python-numpy python-scipy python-astropy
 install:
   - pip install -r requirements.txt
-
 # command to run tests
 script:
   pytest


### PR DESCRIPTION
Travis currently fails to install scipy via pip on Python 2.7.  Let's see if using apt-get fixes this issue, and speeds up the test!