### PR TITLE
Add possibility to convert time during ascii and csv conversion

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -7,3 +7,4 @@ Authors:
 - `Michael Gully-Santiago <https://github.com/gully>`_
 - `Ann Marie Cody <https://github.com/amcody>`_
 - `Christina Hedges <https://github.com/christinahedges>`_
+- `Pierre Zemb <https://github.com/PierreZ>`_

--- a/pyke/kepconvert.py
+++ b/pyke/kepconvert.py
@@ -41,6 +41,43 @@ def kepconvert(infile, conversion, columns, timeformat='', outfile=None, baddata
         * asc2fits
     columns : str
         A comma-delimited list of data column names or descriptors.
+    timeformat: str
+        You can convert the Barycentric Julian Date (BJD) given by FITS files
+        into any subformat supported by Astropy.Time:
+
+        * jd
+
+        * mjd
+
+        * decimalyear
+
+        * unix
+
+        * cxcsec
+
+        * gps
+
+        * plot_date
+
+        * datetime
+
+        * iso
+
+        * isot
+
+        * yday
+
+        * fits
+
+        * byear
+
+        * jyear
+
+        * byear_str
+
+        * jyear_str
+        Be careful that these subformat are for **Solar System Barycenter** and are not
+        Earth-centered.
     baddata : bool
         If **True**, all the rows from the input FITS file are output to an
         ascii file. If **False** then only rows with SAP_QUALITY equal to zero

--- a/pyke/kepconvert.py
+++ b/pyke/kepconvert.py
@@ -12,7 +12,7 @@ from . import kepio, kepmsg, kepkey
 __all__ = ['kepconvert']
 
 
-def kepconvert(infile, conversion, columns, timeformat='', outfile=None, baddata=True,
+def kepconvert(infile, conversion, columns, timeformat='jd', outfile=None, baddata=True,
                overwrite=False, verbose=False, logfile='kepconvert.log'):
     """
     kepconvert -- Convert Kepler FITS time series to or from a different file
@@ -144,7 +144,7 @@ def kepconvert(infile, conversion, columns, timeformat='', outfile=None, baddata
         for colname in tqdm(colnames):
             try:
                 if colname.lower() == 'time':
-                    if len(timeformat) > 0:
+                    if timeformat != "jd":
                         kepmsg.log(logfile, 'KEPCONVERT -- converting BJD to ' +
                                    '{}'.format(timeformat), verbose)
                         times = []
@@ -409,8 +409,8 @@ def kepconvert_main():
     parser.add_argument('infile', help='Name of input file', type=str)
     parser.add_argument('conversion', help='Type of data conversion', type=str,
                         choices=['fits2asc', 'fits2csv', 'asc2fits'], default='fits2asc')
-    parser.add_argument('--timeformat', dest='timeformat', default='',
-                        help="Export time into any subformat handled by astropy.Time",
+    parser.add_argument('--timeformat', dest='timeformat', default='jd',
+                        help="Export time into any subformat handled by astropy.Time (e.g. mjd, iso, decimalyear)",
                         type=str)
     parser.add_argument('--columns', '-c', default='TIME,SAP_FLUX,SAP_FLUX_ERR',
                         dest='columns', help='Comma-delimited list of data columns',

--- a/pyke/kepconvert.py
+++ b/pyke/kepconvert.py
@@ -35,9 +35,7 @@ def kepconvert(infile, conversion, columns, timeformat='', outfile=None, baddata
         Define the type of file conversion:
 
         * fits2asc
-
         * fits2csv
-
         * asc2fits
     columns : str
         A comma-delimited list of data column names or descriptors.
@@ -46,36 +44,22 @@ def kepconvert(infile, conversion, columns, timeformat='', outfile=None, baddata
         into any subformat supported by Astropy.Time:
 
         * jd
-
         * mjd
-
         * decimalyear
-
         * unix
-
         * cxcsec
-
         * gps
-
         * plot_date
-
         * datetime
-
         * iso
-
         * isot
-
         * yday
-
         * fits
-
         * byear
-
         * jyear
-
         * byear_str
-
         * jyear_str
+
         Be careful that these subformat are for **Solar System Barycenter** and are not
         Earth-centered.
     baddata : bool
@@ -425,7 +409,7 @@ def kepconvert_main():
     parser.add_argument('infile', help='Name of input file', type=str)
     parser.add_argument('conversion', help='Type of data conversion', type=str,
                         choices=['fits2asc', 'fits2csv', 'asc2fits'], default='fits2asc')
-    parser.add_argument('timeformat', dest='timeformat', default='',
+    parser.add_argument('--timeformat', dest='timeformat', default='',
                         help="Export time into any subformat handled by astropy.Time",
                         type=str)
     parser.add_argument('--columns', '-c', default='TIME,SAP_FLUX,SAP_FLUX_ERR',

--- a/pyke/tests/test_kepconvert.py
+++ b/pyke/tests/test_kepconvert.py
@@ -13,19 +13,20 @@ def test_kepconvert():
                                 " does not exist")):
 
         kepconvert("myfile.fits", "fits2excel",
-                   "TIME,SAP_FLUX,SAP_FLUX_ERR,SAP_QUALITY", "output.txt",
-                   True, True)
+                   "TIME,SAP_FLUX,SAP_FLUX_ERR,SAP_QUALITY", outfile="output.txt",
+                   baddata=True, overwrite=True, verbose=True)
 
     with pytest.raises(Exception,
                        message=("ERROR -- KEPCONVERT: conversion not supported"
                                 ": fits2excel")):
 
         kepconvert(fake_lc, "fits2excel",
-                   "TIME,SAP_FLUX,SAP_FLUX_ERR,SAP_QUALITY", "output.txt",
-                   True, True)
+                   "TIME,SAP_FLUX,SAP_FLUX_ERR,SAP_QUALITY", outfile="output.txt",
+                   baddata=True, overwrite=True, verbose=True)
 
     # convert to csv
-    kepconvert(fake_lc, "fits2csv", "TIME,SAP_FLUX", "fake_lc.csv", True, True)
+    kepconvert(fake_lc, "fits2csv", "TIME,SAP_FLUX", outfile="fake_lc.csv",
+               baddata=True, overwrite=True, verbose=True)
 
     with open('fake_lc.csv', 'r') as csvfile:
         # check header
@@ -37,12 +38,34 @@ def test_kepconvert():
     delete("fake_lc.csv", "kepconvert.log", False)
 
     # convert to ascii
-    kepconvert(fake_lc, "fits2asc", "TIME,SAP_FLUX", "fake_lc.txt", True, True)
+    kepconvert(fake_lc, "fits2asc", "TIME,SAP_FLUX", outfile="fake_lc.txt",
+               baddata=True, overwrite=True, verbose=True)
 
     with open('fake_lc.txt', 'r') as asciifile:
-        first_line = asciifile.readline()
-        first_line = line.split(',')
+        lines = asciifile.readlines()
+        first_line = lines[0]
+        first_line = first_line.split(',')
         assert first_line == ['TIME', 'SAP_FLUX\n']
 
     delete("fake_lc.txt", "kepconvert.log", False)
 
+    # time conversion
+    with pytest.raises(Exception,
+                       message=("ERROR -- KEPCONVERT: error converting time to nasa: format must be one of ['jd', 'mjd', 'decimalyear', 'unix', 'cxcsec', 'gps', 'plot_date', 'datetime', 'iso', 'isot', 'yday', 'fits', 'byear', 'jyear', 'byear_str', 'jyear_str']")):
+        kepconvert(fake_lc, "fits2csv", "TIME,SAP_FLUX", timeformat='nasa', outfile="fake_lc.txt",
+               baddata=True, overwrite=True, verbose=True)
+
+    kepconvert(fake_lc, "fits2csv", "TIME,SAP_FLUX", timeformat='unix', outfile="fake_lc.txt",
+               baddata=True, overwrite=True, verbose=True)
+
+    with open('fake_lc.txt', 'r') as asciifile:
+        lines = asciifile.readlines()
+        first_line = lines[0]
+        first_line = first_line.split(',')
+        assert first_line == ['TIME', 'SAP_FLUX\n']
+        second_line = lines[1]
+        print(second_line)
+        second_line = second_line.split(',')
+        assert second_line == ['1.461334722059185982e+09', '1.500000000000000000e+01\n']
+
+        delete("fake_lc.txt", "kepconvert.log", False)


### PR DESCRIPTION
With this fix, column 'TIME' can be converted into any astropy.Time supported subformat such as:

* jd
* mjd
* decimalyear
* unix
* cxcsec
* gps
* plot_date
* datetime
* iso
* isot
* yday
* fits
* byear
* jyear
* byear_str
* jyear_str