### PR TITLE
[BUG]: PRF2DET implementation is wrong for nsources > 1

### DIFF
--- a/pyke/kepfunc.py
+++ b/pyke/kepfunc.py
@@ -313,7 +313,8 @@ def PRF2DET(flux, OBJx, OBJy, DATx, DATy, wx, wy, a, splineInterpolation):
                 yy = y - INTy + FRCy
                 dx = xx * cosa - yy * sina
                 dy = xx * sina + yy * cosa
-                PRFfit[j, k] += PRFfit[j,k] + splineInterpolation(dy * wy, dx * wx) * flux[i]
+                PRFfit[j, k] = PRFfit[j, k] + splineInterpolation(dy * wy, dx * wx) * flux[i]
+
     return PRFfit
 
 def PRF(params, *args):

--- a/pyke/kepfunc.py
+++ b/pyke/kepfunc.py
@@ -256,33 +256,6 @@ def PRFgauss2d(params, *args):
     return res
 
 
-def PRF2DET2(flux, OBJx, OBJy, DATx, DATy, splineInterpolation):
-    """
-    PRF interpolation function
-    """
-    # where in the pixel is the source position?
-    PRFfit = np.zeros((np.size(DATy), np.size(DATx)))
-    for i in range(len(flux)):
-        FRCx, INTx = modf(OBJx[i])
-        FRCy, INTy = modf(OBJy[i])
-        if FRCx > 0.5:
-            FRCx -= 1.0
-            INTx += 1.0
-        if FRCy > 0.5:
-            FRCy -= 1.0
-            INTy += 1.0
-        FRCx = -FRCx
-        FRCy = -FRCy
-
-    # constuct model PRF in detector coordinates
-        for (j, y) in enumerate(DATy):
-            for (k, x) in enumerate(DATx):
-                dy = y - INTy + FRCy
-                dx = x - INTx + FRCx
-                PRFfit[j, k] = PRFfit[j, k] + splineInterpolation(dy, dx) * flux[i]
-    return PRFfit
-
-
 def PRF2DET(flux, OBJx, OBJy, DATx, DATy, wx, wy, a, splineInterpolation):
     """
     PRF interpolation function


### PR DESCRIPTION
A few tests (and the somewhat unconventional notation of ``x += x + c``) indicate that https://github.com/KeplerGO/PyKE/blob/master/pyke/kepfunc.py#L316 should be:

```
PRFfit[j, k] = PRFfit[j, k] + splineInterpolation(dy * wy, dx * wx) * flux[i]
```

I repeated the example in http://pyke.keplerscience.org/en/latest/api/kepprf.html with the changes presented in this PR and I got the following results:

```
Flux = 7956.0812515047555 e-/s X = 829.8259431097925 pix Y = 242.38103344786273 pix
Flux = 4734.069273781816 e-/s X = 830.9908055510256 pix Y = 240.9734036663847 pix

                Total flux in mask = 10747.293440635602 e-/s
               Target flux in mask = 7586.083858936443 e-/s
            Total flux in aperture = 6365.55148763003 e-/s
           Target flux in aperture = 6221.849607139645 e-/s
  Target flux fraction in aperture = 78.2024392468703 %
Contamination fraction in aperture = 2.257493019570052 %
```
The plot showed above strongly suggests that the values reported in ``Total flux in aperture`` and ``Target flux in aperture`` make more sense after the change in the code (same conclusion for ``Contamination fraction in aperture``)

![screen shot 2017-08-30 at 2 43 47 pm](https://user-images.githubusercontent.com/13077051/29896402-ac8738ae-8d91-11e7-8cfd-49108a692029.png)

Fix #99.
cc @barentsen @rpoleski