### PR TITLE
Add functions to convert between Kepler CCD channel number and (module, output) numbers

### DIFF
--- a/pyke/tests/test_utils.py
+++ b/pyke/tests/test_utils.py
@@ -2,6 +2,8 @@ import pytest
 import argparse
 
 from ..utils import PyKEArgumentHelpFormatter
+from ..utils import module_output_to_channel, channel_to_module_output
+
 
 def test_PyKEArgumentHelpFormatter():
     parser = argparse.ArgumentParser(
@@ -21,3 +23,16 @@ def test_PyKEArgumentHelpFormatter():
            "--bool_arg         bool type argument", '']
     assert ans == formatter.format_help().split('\n')
 
+
+def test_channel_to_module_output():
+    assert channel_to_module_output(1) == (2, 1)
+    assert channel_to_module_output(42) == (13, 2)
+    assert channel_to_module_output(84) == (24, 4)
+    assert channel_to_module_output(33) == (11, 1)
+
+
+def test_module_output_to_channel():
+    assert module_output_to_channel(2, 1) == 1
+    assert module_output_to_channel(13, 2) == 42
+    assert module_output_to_channel(24, 4) == 84
+    assert module_output_to_channel(11, 1) == 33

--- a/pyke/utils.py
+++ b/pyke/utils.py
@@ -1,4 +1,6 @@
+import numpy as np
 from argparse import HelpFormatter, SUPPRESS, OPTIONAL, ZERO_OR_MORE
+
 
 class PyKEArgumentHelpFormatter(HelpFormatter):
     """Help message formatter which adds default values to argument help,
@@ -14,3 +16,56 @@ class PyKEArgumentHelpFormatter(HelpFormatter):
                 if action.option_strings or action.nargs in defaulting_nargs:
                     help += ' (default: %(default)s)'
         return help
+
+
+def module_output_to_channel(module, output):
+    """Returns the cCCD channel number for a given module and output pair."""
+    if module < 1 or module > 26:
+        raise ValueError("Module number must be in range 1-26.")
+    if output < 1 or output > 4:
+        raise ValueError("Output number must be 1, 2, 3, or 4.")
+    return _get_channel_lookup_array()[module, output]
+
+
+def channel_to_module_output(channel):
+    """Returns a (module, output) pair given a CCD channel number."""
+    if channel < 1 or channel > 88:
+        raise ValueError("Channel number must be in the range 1-88.")
+    lookup = _get_channel_lookup_array()
+    lookup[:,0] = 0
+    modout = np.where(lookup == channel)
+    return (modout[0][0], modout[1][0])
+
+
+def _get_channel_lookup_array():
+    """Returns a lookup table which maps (module, output) onto channel."""
+    # In the array below, channel == array[module][output]
+    # Note: modules 1, 5, 21, 25 are the FGS guide star CCDs.
+    return np.array([
+       [0,     0,    0,    0,    0],
+       [1,    85,    0,    0,    0],
+       [2,     1,    2,    3,    4],
+       [3,     5,    6,    7,    8],
+       [4,     9,   10,   11,   12],
+       [5,    86,    0,    0,    0],
+       [6,    13,   14,   15,   16],
+       [7,    17,   18,   19,   20],
+       [8,    21,   22,   23,   24],
+       [9,    25,   26,   27,   28],
+       [10,   29,   30,   31,   32],
+       [11,   33,   34,   35,   36],
+       [12,   37,   38,   39,   40],
+       [13,   41,   42,   43,   44],
+       [14,   45,   46,   47,   48],
+       [15,   49,   50,   51,   52],
+       [16,   53,   54,   55,   56],
+       [17,   57,   58,   59,   60],
+       [18,   61,   62,   63,   64],
+       [19,   65,   66,   67,   68],
+       [20,   69,   70,   71,   72],
+       [21,   87,    0,    0,    0],
+       [22,   73,   74,   75,   76],
+       [23,   77,   78,   79,   80],
+       [24,   81,   82,   83,   84],
+       [25,   88,    0,    0,    0],
+       ])


### PR DESCRIPTION
Kepler uses both channel numbers and "module.output" notations to identify different parts of the focal plane.  This PR adds functions to convert between both.  @mirca or @gully please review and merge!