### PR TITLE
Add a parse_kepler_quality_flags function

### DIFF
--- a/pyke/tests/test_utils.py
+++ b/pyke/tests/test_utils.py
@@ -3,6 +3,7 @@ import argparse
 
 from ..utils import PyKEArgumentHelpFormatter
 from ..utils import module_output_to_channel, channel_to_module_output
+from ..utils import KEPLER_QUALITY_FLAGS, parse_kepler_quality_flags
 
 
 def test_PyKEArgumentHelpFormatter():
@@ -36,3 +37,13 @@ def test_module_output_to_channel():
     assert module_output_to_channel(13, 2) == 42
     assert module_output_to_channel(24, 4) == 84
     assert module_output_to_channel(11, 1) == 33
+
+
+def test_parse_kepler_quality_flags():
+    flags = list(KEPLER_QUALITY_FLAGS.items())
+    # Can we recover each individual quality flag?
+    for key, value in flags:
+        assert parse_kepler_quality_flags(key)[0] == value
+    # Can we recover combinations of flags?
+    assert parse_kepler_quality_flags(flags[5][0] + flags[7][0]) == [flags[5][1], flags[7][1]]
+    assert parse_kepler_quality_flags(flags[3][0] + flags[4][0] + flags[5][0]) == [flags[3][1], flags[4][1], flags[5][1]]

--- a/pyke/utils.py
+++ b/pyke/utils.py
@@ -1,6 +1,56 @@
 import numpy as np
 from argparse import HelpFormatter, SUPPRESS, OPTIONAL, ZERO_OR_MORE
 
+# Dictionary describing the meaning of the various Kepler QUALITY flags,
+# as documented in the Kepler Archive Manual (Table 2.3).
+KEPLER_QUALITY_FLAGS = {
+    1: "Attitude tweak",
+    2: "Safe mode",
+    4: "Coarse point",
+    8: "Earth point",
+    16: "Zero crossing",
+    32: "Desaturation event",
+    64: "Argabrightening",
+    128: "Cosmic ray in optimal aperture",
+    256: "Manual exclude",
+    1024: "Sudden sensitivity dropout",
+    2048: "Impulsive outlier",
+    4096: "Argabrightening",
+    8192: "Cosmic ray in collateral data",
+    16384: "Detector anomaly",
+    32768: "No fine point",
+    65536: "No data",
+    131072: "Rolling band in optimal aperture",
+    262144: "Rolling band in full mask",
+    524288: "Possible thruster firing",
+    1048576: "Thruster firing"
+}
+
+
+def parse_kepler_quality_flags(quality):
+    """Converts a Kepler QUALITY value into a list of human-readable strings.
+
+    This function takes the QUALITY bitstring that can be found for each
+    cadence in Kepler/K2's pixel and light curve files and converts into
+    a list of human-readable strings explaining the flags raised (if any).
+
+    Parameters
+    ----------
+    quality : int
+        Value from the 'QUALITY' column of a Kepler/K2 pixel or lightcurve file.
+
+    Returns
+    -------
+    flags : list of str
+        List of human-readable strings giving a short description of the
+        quality flags raised.  Returns an empty list if no flags raised.
+    """
+    flags = []
+    for flag in KEPLER_QUALITY_FLAGS.keys():
+        if quality & flag > 0:
+            flags.append(KEPLER_QUALITY_FLAGS[flag])
+    return flags
+
 
 class PyKEArgumentHelpFormatter(HelpFormatter):
     """Help message formatter which adds default values to argument help,


### PR DESCRIPTION
I propose to add a `parse_kepler_quality_flags` function to translate the value of QUALITY integers into a human-readable list of qualify flags. @gully may find this helpful in his current work?