### PR TITLE
Updated kepfold to automatically search for periods from KEPBLS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 3.1 (unreleased)
 ================
 
+- [#130] kepfold API updated to include optional keywords for period and BJD0.
+  kepfold will otherwise search for period and BJD0 keywords in the input fits file.
 
 3.0 (2017-09-18)
 ================
@@ -22,4 +24,3 @@ PyKE 3.0.0 is a major release which provides the following key improvements:
   [user contributions](http://pyke.keplerscience.org/en/latest/contributing.html#contributing).
 
 - The core code has been refactored to become more developer-friendly.
-

--- a/pyke/kepflatten.py
+++ b/pyke/kepflatten.py
@@ -296,7 +296,8 @@ def kepflatten(infile, outfile=None, datacol='PDCSAP_FLUX',
     masterfit[-1] = masterfit[-4] #fudge
     masterfit[-2] = masterfit[-4] #fudge
     masterfit[-3] = masterfit[-4] #fudge
-    plt.plot(intime - intime0, masterfit / 10 ** nrm, 'b')
+    if plot:
+        plt.plot(intime - intime0, masterfit / 10 ** nrm, 'b')
 
     # reject outliers
     rejtime, rejdata = [], []

--- a/pyke/kepfold.py
+++ b/pyke/kepfold.py
@@ -113,14 +113,18 @@ def kepfold(infile, period=None, bjd0=None, outfile=None, bindata=False,
     # check if there is period or BJD0 information
     if np.any([(period is None),(bjd0 is None)]):
         # open input file
+        kepmsg.log(logfile,'KEPFOLD -- Searching for periods in headers.',verbose)
         instr = pyfits.open(infile, 'readonly')
-        try:
-            if period is None:
-                period = instr[3].header['PERIOD']
-            if bjd0 is None:
-                bjd0 = instr[3].header['BJD0']
-            kepmsg.log(logfile,'Using period and BJD0 from KEPBLS',verbose)
-        except:
+        if period is None:
+            for i in instr:
+                if 'PERIOD' in i.header:
+                    period = i.header['PERIOD']
+        if bjd0 is None:
+            for i in instr:
+                if 'BJD0' in i.header:
+                    bjd0 = i.header['BJD0']
+
+        if np.all([(period is None),(bjd0 is None)]):
             errmsg = ('ERROR -- KEPFOLD: No period information found. Either specify'
             'period and BJD0 or run KEPBLS.')
             kepmsg.err(logfile, errmsg, verbose)

--- a/pyke/kepfold.py
+++ b/pyke/kepfold.py
@@ -115,13 +115,14 @@ def kepfold(infile, period=None, bjd0=None, outfile=None, bindata=False,
         # open input file
         instr = pyfits.open(infile, 'readonly')
         try:
-            period = instr[3].header['PERIOD']
-            bjd0 = instr[3].header['BJD0']
+            if period is None:
+                period = instr[3].header['PERIOD']
+            if bjd0 is None:
+                bjd0 = instr[3].header['BJD0']
             kepmsg.log(logfile,'Using period and BJD0 from KEPBLS',verbose)
         except:
-            errmsg = ('ERROR -- KEPFOLD: No period information found. Either specify \
-            period and BJD0 or run KEPBLS.'
-                      .format(outfile))
+            errmsg = ('ERROR -- KEPFOLD: No period information found. Either specify'
+            'period and BJD0 or run KEPBLS.')
             kepmsg.err(logfile, errmsg, verbose)
 
     # log the call

--- a/pyke/kepfold.py
+++ b/pyke/kepfold.py
@@ -6,15 +6,15 @@ from scipy import stats
 from astropy.io import fits as pyfits
 from matplotlib import pyplot as plt
 from tqdm import tqdm
-
+import re
 
 __all__ = ['kepfold']
 
 
 def kepfold(infile, period=None, bjd0=None, outfile=None, bindata=False,
             binmethod='median', threshold=1.0, niter=5, nbins=1000,
-            rejqual=False, plottype='det', overwrite=False, verbose=False,
-            logfile="kepfold.log"):
+            rejqual=False, plottype='det',noninteractive=False, overwrite=False,
+            verbose=False, logfile="kepfold.log"):
     """
     kepfold: Phase-fold light curve data on linear ephemeris.
 
@@ -87,6 +87,8 @@ def kepfold(infile, period=None, bjd0=None, outfile=None, bindata=False,
         * ``det`` data has been detrended using piecemeal polynomials with the
           kepflatten tool. DET data is stored in the column DETSAP_FLUX.
 
+    non-interactive : bool
+        If True, prevents the matplotlib window to pop up.
     overwrite : bool
         Overwrite the output file?
     verbose : bool
@@ -587,7 +589,10 @@ def kepfold(infile, period=None, bjd0=None, outfile=None, bindata=False,
         else:
             plt.ylim(1.0e-10, ymax + yr * 0.01)
         plt.grid()
-        plt.show()
+        plt.savefig(re.sub('.fits', '.png', outfile),bbox_inches='tight')
+        if not noninteractive:
+            plt.show()
+
     # close input file
     instr.close()
     # stop time
@@ -623,6 +628,9 @@ def kepfold_main():
                         help='Reject bad quality timestamps?')
     parser.add_argument('--plottype', default='det', help='plot type',
                         type=str, choices=['sap', 'pdc', 'cbv', 'det','None'])
+    parser.add_argument('--non-interactive', action='store_true',
+                        help='Pop up matplotlib plot window?',
+                        dest='noninteractive')
     parser.add_argument('--overwrite', action='store_true',
                         help='Overwrite output file?')
     parser.add_argument('--verbose', action='store_true',
@@ -633,5 +641,5 @@ def kepfold_main():
 
     kepfold(args.infile, args.period, args.bjd0, args.outfile, args.bindata,
             args.binmethod, args.threshold, args.niter, args.nbins,
-            args.quality, args.plottype, args.overwrite, args.verbose,
+            args.quality, args.plottype, args.noninteractive, args.overwrite, args.verbose,
             args.logfile)


### PR DESCRIPTION
Now when you run kepfold on a kepbls'd fits file it will use the best fitting period/bjd0.
However, this does mean that instead of running

`kepfold filename 10 100`

You have to run

`kepfold filename -period 10 -bjd0 100`

How does everyone feel about that?

This fixes #129 