### PR TITLE
Add method get_prf_model in KeplerTargetPixelFile

### DIFF
--- a/pyke/prf.py
+++ b/pyke/prf.py
@@ -7,7 +7,6 @@ import sys
 from astropy.io import fits as pyfits
 from oktopus.posterior import PoissonPosterior
 from .utils import channel_to_module_output, plot_image
-from .targetpixelfile import KeplerTargetPixelFile
 
 # This is a workaround to get the number of arguments of
 # a given function.
@@ -254,28 +253,6 @@ class KeplerPRF(object):
                  rotation_angle):
         return self.evaluate(flux, center_col, center_row,
                              scale_col, scale_row, rotation_angle)
-
-    @classmethod
-    def from_tpf(cls, tpf):
-        """Returns an object of KeplerPRF (or its subclasses)
-        initialized using the necessary metadata in the tpf object.
-
-        Parameters
-        ----------
-        tpf : instance of TargetPixelFile (or its subclasses) or str
-            An object from the TargetPixelFile class or from any of its
-            subclasses or the address (url or local) of a target pixel file
-
-        Returns
-        -------
-        prf : instance of KeplerPRF (or its subclasses)
-        """
-
-        if isinstance(tpf, str):
-            tpf = KeplerTargetPixelFile(tpf)
-
-        return cls(channel=tpf.channel, shape=tpf.shape[1:],
-                   column=tpf.column, row=tpf.row)
 
     def evaluate(self, flux, center_col, center_row, scale_col, scale_row,
                  rotation_angle):

--- a/pyke/prf.py
+++ b/pyke/prf.py
@@ -7,6 +7,7 @@ import sys
 from astropy.io import fits as pyfits
 from oktopus.posterior import PoissonPosterior
 from .utils import channel_to_module_output, plot_image
+from .targetpixelfile import KeplerTargetPixelFile
 
 # This is a workaround to get the number of arguments of
 # a given function.
@@ -253,6 +254,28 @@ class KeplerPRF(object):
                  rotation_angle):
         return self.evaluate(flux, center_col, center_row,
                              scale_col, scale_row, rotation_angle)
+
+    @classmethod
+    def from_tpf(cls, tpf):
+        """Returns an object of KeplerPRF (or its subclasses)
+        initialized using the necessary metadata in the tpf object.
+
+        Parameters
+        ----------
+        tpf : instance of TargetPixelFile (or its subclasses) or str
+            An object from the TargetPixelFile class or from any of its
+            subclasses or the address (url or local) of a target pixel file
+
+        Returns
+        -------
+        prf : instance of KeplerPRF (or its subclasses)
+        """
+
+        if isinstance(tpf, str):
+            tpf = KeplerTargetPixelFile(tpf)
+
+        return cls(channel=tpf.channel, shape=tpf.shape[1:],
+                   column=tpf.column, row=tpf.row)
 
     def evaluate(self, flux, center_col, center_row, scale_col, scale_row,
                  rotation_angle):

--- a/pyke/targetpixelfile.py
+++ b/pyke/targetpixelfile.py
@@ -3,6 +3,7 @@ import scipy
 import matplotlib.pyplot as plt
 from astropy.io import fits
 from .lightcurve import KeplerLightCurve, LightCurve
+from .prf import SimpleKeplerPRF
 from .utils import KeplerQualityFlags, plot_image
 
 
@@ -79,6 +80,18 @@ class KeplerTargetPixelFile(TargetPixelFile):
     def header(self, ext=0):
         """Returns the header for a given extension."""
         return self.hdu[ext].header
+
+    def get_prf_model(self):
+        """Returns an object of SimpleKeplerPRF initialized using the
+        necessary metadata in the tpf object.
+
+        Returns
+        -------
+        prf : instance of SimpleKeplerPRF
+        """
+
+        return SimpleKeplerPRF(channel=self.channel, shape=self.shape[1:],
+                               column=self.column, row=self.row)
 
     @property
     def keplerid(self):

--- a/pyke/tests/test_prf.py
+++ b/pyke/tests/test_prf.py
@@ -98,17 +98,16 @@ def test_scene_model():
     assert scene.bkg_order == 1
     assert (scene.n_params == [0, 3]).all()
 
-def test_from_tpf():
+def test_get_model_prf():
     tpf_fn = get_pkg_data_filename("data/test-tpf-star.fits")
     tpf = KeplerTargetPixelFile(tpf_fn)
 
     prf = SimpleKeplerPRF(channel=tpf.channel, shape=tpf.shape[1:],
                           column=tpf.column, row=tpf.row)
-    prf_from_str = SimpleKeplerPRF.from_tpf(tpf_fn)
-    prf_from_tpf = SimpleKeplerPRF.from_tpf(tpf)
+    prf_from_tpf = tpf.get_prf_model()
 
-    assert type(prf) == type(prf_from_str) == type(prf_from_tpf)
-    assert prf.channel == prf_from_str.channel == prf_from_tpf.channel
-    assert prf.shape == prf_from_str.shape == prf_from_tpf.shape
-    assert prf.column == prf_from_str.column == prf_from_tpf.column
-    assert prf.row == prf_from_str.row == prf_from_tpf.row
+    assert type(prf) == type(prf_from_tpf)
+    assert prf.channel == prf_from_tpf.channel
+    assert prf.shape == prf_from_tpf.shape
+    assert prf.column == prf_from_tpf.column
+    assert prf.row == prf_from_tpf.row


### PR DESCRIPTION
This method makes it easier to create a PRF object from a given target pixel file.

~I wonder if this should rather be the default behavior in ``__init__`` and
then we have a method ``from_meta_data`` which takes the parameters that the current constructor takes.~

what your feelings? @barentsen  
  