### PR TITLE
Add normalization parameter back to `LightCurve.cdpp()`

### DIFF
--- a/pyke/lightcurve.py
+++ b/pyke/lightcurve.py
@@ -174,7 +174,7 @@ class LightCurve(object):
         return new_lc
 
     def cdpp(self, transit_duration=13, savgol_window=101, savgol_polyorder=2,
-             sigma_clip=5.):
+             sigma_clip=5., norm_factor=1.4):
         """Estimate the CDPP noise metric using the Savitzky-Golay (SG) method.
 
         An interesting estimate of the noise in a lightcurve is the scatter that
@@ -207,6 +207,13 @@ class LightCurve(object):
         sigma_clip : float, optional
             The number of standard deviations to use for clipping outliers.
             The default is 5.
+        norm_factor : float, optional
+            Noise normalization factor for the SG filter.  Recommended
+            value for 13 cadence transit and 101 cadence window is 1.4.
+            The normalization factor is determined by passing White Gaussian
+            Noise to the same filter and using it to normalize the cdpp
+            such that this function scales exactly as 1/sqrt(transit_duration)
+            for white noise.
 
         Returns
         -------
@@ -225,7 +232,7 @@ class LightCurve(object):
                                     polyorder=savgol_polyorder)
         cleaned_lc = detrended_lc.remove_outliers(sigma=sigma_clip)
         mean = running_mean(data=cleaned_lc.flux, window_size=transit_duration)
-        cdpp_ppm = np.std(mean) * 1e6
+        cdpp_ppm = norm_factor * np.std(mean) * 1e6
         return cdpp_ppm
 
     def to_csv(self):

--- a/pyke/tests/test_lightcurve.py
+++ b/pyke/tests/test_lightcurve.py
@@ -48,18 +48,18 @@ def test_lightcurve_fold():
 def test_cdpp():
     """Test the basics of the CDPP noise metric."""
     # A flat lightcurve should have a CDPP close to zero
-    assert_almost_equal(LightCurve(np.arange(200), np.ones(200)).cdpp(), 0)
+    assert_almost_equal(LightCurve(np.arange(200), np.ones(200)).cdpp(norm_factor=1), 0)
     # An artificial lightcurve with sigma=100ppm should have cdpp=100ppm
     lc = LightCurve(np.arange(10000), np.random.normal(loc=1, scale=100e-6, size=10000))
-    assert_almost_equal(lc.cdpp(transit_duration=1), 100, decimal=-0.5)
+    assert_almost_equal(lc.cdpp(transit_duration=1, norm_factor=1), 100, decimal=-0.5)
 
 
 def test_cdpp_tabby():
     """Compare the cdpp noise metric against the pipeline value."""
     lcf = KeplerLightCurveFile(TABBY_Q8)
-    # Tabby's star shows dips after cadence 1000 which increase the cdpp
-    lc = LightCurve(lcf.PDCSAP_FLUX.time[:1000], lcf.PDCSAP_FLUX.flux[:1000])
-    assert(np.abs(lc.cdpp() - lcf.header(ext=1)['CDPP6_0']) < 30)
+    # Tabby's star shows dips after cadence 1000 which may confuse the cdpp
+    lc = LightCurve(lcf.PDCSAP_FLUX.time, lcf.PDCSAP_FLUX.flux)
+    assert_almost_equal(lc.cdpp(), lcf.header(ext=1)['CDPP6_0'])
 
 
 def test_lightcurve_plot():


### PR DESCRIPTION
This PR adds the normalization constant argument back to the `cdpp` method.

The CDPP implementation from JVC suggests the savgol-based CDPP should be multiplied by 1.4, however I am finding that it should be closer to 1.19:

```
python -c "import numpy as np; from pyke import LightCurve; print(1/np.sqrt(13)/LightCurve(range(1000000), 1+np.random.normal(loc=0, scale=1e-6, size=1000000)).cdpp(norm_factor=1))"
1.19047139601
```

More work is required to understand the normalization factor.  For now, this PR will make the unit test fail because PyKE's cdpp does not quite match the pipeline's. (But then again the unit test compares the values for Tabby's star, we should really add a quiet star to the unit tests for this.)