### PR TITLE
Add a function that returns the list of CBVs that maximizes the Bayes factor

### DIFF
--- a/pyke/lightcurve.py
+++ b/pyke/lightcurve.py
@@ -942,7 +942,7 @@ class KeplerCBVCorrector(object):
             cbv_list = list(range(1, n+1))
             self.correct(cbv_list, options={'xtol': 1e-6, 'ftol':1e-6, 'maxfev': 2000})
             cost.append(self.opt_result.fun)
-            self.bayes_factor.append(math.fabs((cost[n-1] - cost[n-2])))
+            self.bayes_factor.append((cost[n-2] - cost[n-1]))
         k = np.argmin(self.bayes_factor)
         # transform to get the actual Bayes factor
         self.bayes_factor = np.exp(-np.array(self.bayes_factor))

--- a/pyke/lightcurve.py
+++ b/pyke/lightcurve.py
@@ -102,7 +102,7 @@ class LightCurve(object):
             flatten_lc.flux_err = lc_clean.flux_err / trend_signal
 
         if return_trend:
-            trend_lc = copy.copy(self)
+            trend_lc = copy.copy(lc_clean)
             trend_lc.flux = trend_signal
             return flatten_lc, trend_lc
         return flatten_lc

--- a/pyke/lightcurve.py
+++ b/pyke/lightcurve.py
@@ -841,7 +841,7 @@ class KeplerCBVCorrector(object):
         self.lc_file = lc_file
         self.likelihood = likelihood
         self.prior = prior
-        self._ncbvs = 15 # number of cbvs for Kepler/K2
+        self._ncbvs = 16 # number of cbvs for Kepler/K2
 
         if self.lc_file.mission == 'Kepler':
             self.cbv_base_url = "http://archive.stsci.edu/missions/kepler/cbv/"

--- a/pyke/lightcurve.py
+++ b/pyke/lightcurve.py
@@ -926,12 +926,16 @@ class KeplerCBVCorrector(object):
 
     def get_cbvs_list(self, method='bayes-factor'):
         """Returns the subsequence of subsequent CBVs that maximizes
-        Bayes' factor.
+        Bayes' factor [1]_.
 
         Returns
         -------
         cbv_list : list
             Subsequence of subsequent CBVs that maximizes the Bayes' factor.
+
+        References
+        ----------
+        .. [1] https://en.wikipedia.org/wiki/Bayes_factor
         """
 
         self.bayes_factor, cost = [], [] # bayes_factor here is actually the

--- a/pyke/lightcurve.py
+++ b/pyke/lightcurve.py
@@ -942,10 +942,19 @@ class KeplerCBVCorrector(object):
             cbv_list = list(range(1, n+1))
             self.correct(cbv_list, options={'xtol': 1e-6, 'ftol':1e-6, 'maxfev': 2000})
             cost.append(self.opt_result.fun)
+            # cost is the negative log of the posterior evaluated at the
+            # Maximum A Posterior Probability (MAP) estimator
             self.bayes_factor.append((cost[n-2] - cost[n-1]))
+            # so cost[n-2] - cost[n-1] = -log(p1) + log(p2) = log(p2/p1)
+            # where p1 is the posterior probability (evaluated at the MAP)
+            # for the model with n-2 cbvs and p2 is the posterior probability
+            # also evaluated at the MAP for the model with n-1 cbvs
         k = np.argmin(self.bayes_factor)
         # transform to get the actual Bayes factor
         self.bayes_factor = np.exp(-np.array(self.bayes_factor))
+        # the k+2 here comes from the fact that Python indexes begin
+        # from 0 and we count CBVs starting from 1 and also
+        # note that range(1, k) equals the interval [1, k), which excludes k.
         return list(range(1, k+2))
 
     def get_cbv_url(self):

--- a/pyke/targetpixelfile.py
+++ b/pyke/targetpixelfile.py
@@ -255,8 +255,8 @@ class KeplerTargetPixelFile(TargetPixelFile):
         yy = self.row + yy
         xx = self.column + xx
         total_flux = np.nansum(self.flux[:, aperture_mask], axis=1)
-        col_centr = np.nansum(xx * aperture_mask * self.flux) / total_flux
-        row_centr = np.nansum(yy * aperture_mask * self.flux) / total_flux
+        col_centr = np.nansum(xx * aperture_mask * self.flux, axis=(1, 2)) / total_flux
+        row_centr = np.nansum(yy * aperture_mask * self.flux, axis=(1, 2)) / total_flux
 
         return col_centr, row_centr
 

--- a/pyke/tests/test_targetpixelfile.py
+++ b/pyke/tests/test_targetpixelfile.py
@@ -34,6 +34,10 @@ def test_tpf_ones():
     tpf = KeplerTargetPixelFile(filename_tpf_one_center)
     lc = tpf.to_lightcurve(aperture_mask='all')
     assert np.all(lc.flux == 1)
+    assert np.all((lc.centroid_col < tpf.column+tpf.shape[1]).all()
+                  * (lc.centroid_col > tpf.column).all())
+    assert np.all((lc.centroid_row < tpf.row+tpf.shape[2]).all()
+                  * (lc.centroid_row > tpf.row).all())
 
 def test_quality_flag_decoding():
     """Can the QUALITY flags be parsed correctly?"""


### PR DESCRIPTION
It's pretty inconvenient (although useful) to make a plot like this https://user-images.githubusercontent.com/13077051/35116010-cc682d06-fc3e-11e7-80ef-0f2cf2127be3.png
every time one wants to use the CBV correction in order to find out a good set of CBVs.

~In light of #177, I propose we add this function which finds the smallest "good" list of CBVs by comparing the fitting error between subsequent lists of CBVs.~

~For instance, I get ``range(1, 11)`` for the example above, and ``[1, 2]`` for this
example (Tabby's star)~
