### PR TITLE
Add a LightCurve.normalize() method

### DIFF
--- a/pyke/lightcurve.py
+++ b/pyke/lightcurve.py
@@ -134,6 +134,23 @@ class LightCurve(object):
             return LightCurve(fold_time[sorted_args], self.flux[sorted_args])
         return LightCurve(fold_time[sorted_args], self.flux[sorted_args], flux_err=self.flux_err[sorted_args])
 
+    def normalize(self):
+        """Returns a normalized version of the lightcurve.
+
+        The normalized lightcurve is obtained by dividing `flux` and `flux_err`
+        by the median flux.
+
+        Returns
+        -------
+        normalized_lightcurve : LightCurve object
+            A new ``LightCurve`` in which the flux is normalized to 1.
+        """
+        lc = copy.copy(self)
+        if lc.flux_err is not None:
+            lc.flux_err = lc.flux_err / np.nanmedian(lc.flux)
+        lc.flux = lc.flux / np.nanmedian(lc.flux)
+        return lc
+
     def remove_nans(self):
         """Removes cadences where the flux is NaN.
 
@@ -309,7 +326,7 @@ class LightCurve(object):
             A matplotlib axes object to plot into. If no axes is provided,
             a new one be generated.
         normalize : bool
-            Normalized the lightcurve
+            Normalize the lightcurve before plotting?
         xlabel : str
             Plot x axis label
         ylabel : str
@@ -332,18 +349,17 @@ class LightCurve(object):
         """
         if ax is None:
             fig, ax = plt.subplots(1)
-        flux = self.flux
-        flux_err = self.flux_err
         if normalize:
-            if flux_err is not None:
-                flux_err = flux_err / np.nanmedian(flux)
-            flux = flux / np.nanmedian(flux)
-        if flux_err is None:
-            ax.plot(self.time, flux, marker='o', color=color, linestyle=linestyle,
-                       **kwargs)
+            normalized_lc = self.normalize()
+            flux, flux_err = normalized_lc.flux, normalized_lc.flux_err
         else:
-            ax.errorbar(self.time, flux, flux_err, color=color, linestyle=linestyle,
-                        **kwargs)
+            flux, flux_err = self.flux, self.flux_err
+        if flux_err is None:
+            ax.plot(self.time, flux, marker='o', color=color,
+                    linestyle=linestyle, **kwargs)
+        else:
+            ax.errorbar(self.time, flux, flux_err, color=color,
+                        linestyle=linestyle, **kwargs)
         if fill:
             ax.fill(self.time, flux, fc='#a8a7a7', linewidth=0.0, alpha=0.3)
         if grid:

--- a/pyke/lightcurve.py
+++ b/pyke/lightcurve.py
@@ -143,7 +143,8 @@ class LightCurve(object):
         Returns
         -------
         normalized_lightcurve : LightCurve object
-            A new ``LightCurve`` in which the flux is normalized to 1.
+            A new ``LightCurve`` in which `flux` and `flux_err` are divided
+            by the median.
         """
         lc = copy.copy(self)
         if lc.flux_err is not None:

--- a/pyke/tests/test_lightcurve.py
+++ b/pyke/tests/test_lightcurve.py
@@ -117,6 +117,7 @@ def test_sff_corrector():
     assert_almost_equal(sff.interp(sff.s), correction, decimal=3)
     assert_array_equal(time, klc.time)
 
+
 def test_bin():
     lc = LightCurve(time=np.arange(10), flux=2*np.ones(10),
                     flux_err=2**.5*np.ones(10))
@@ -124,3 +125,9 @@ def test_bin():
     assert_allclose(binned_lc.flux, 2*np.ones(5))
     assert_allclose(binned_lc.flux_err, np.ones(5))
     assert len(binned_lc.time) == 5
+
+
+def test_normalize():
+    """Does the `LightCurve.normalize()` method normalize the flux?"""
+    lc = LightCurve(time=np.arange(10), flux=5*np.ones(10))
+    assert_allclose(np.median(lc.normalize().flux), 1)


### PR DESCRIPTION
I propose to add a simple `LightCurve.normalize()` method which returns a copy of the LightCurve where the `flux` and `flux_err` are divided by the median flux.  This is a trivial operation, but typing `normalize()` is nevertheless a lot more fun than doing it by hand.

I also changed `LightCurve.plot()` to call this method if `normalize=True`.